### PR TITLE
Resolve JS and JSX dependencies

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
 
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: [".ts", ".tsx"]
+    extensions: [".ts", ".tsx", ".js", ".jsx"]
   },
 
   module: {


### PR DESCRIPTION
What
----

Buba would like to rely on dependencies such as react-router-dom, which
need some extra attention whilst working with in TypeScript.

We can add the extensions to the Webpack configuration and rely on it to
resolve our dependencies in a good way, unblocking Buba...

How to review
-------------

- `git rebase origin/help-buba`
- `npm run start`
