### PR TITLE
Ease on GitHub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: Test, Lint and Build
 
 on:
-  - push
   - pull_request
 
 jobs:


### PR DESCRIPTION
What
----

It appears that the actions are triggered twice. Once on Commit being
pushed and once on Pull Request being created.

This doesn't need to happen on both. In fact, it probably doesn't need
to happen on every push, where it's sometimes the case people push WIP
commits.

Running it once upon a Pull Request should be enough for us to safely
merge change.

How to review
-------------

- Sanity check
