### PR TITLE
add simple navigation containing group

### DIFF
--- a/src/components/communities/communities.scss
+++ b/src/components/communities/communities.scss
@@ -1,0 +1,2 @@
+.c-communities {
+}

--- a/src/components/communities/communities.test.tsx
+++ b/src/components/communities/communities.test.tsx
@@ -1,16 +1,15 @@
 import { mount } from 'enzyme';
 import React from 'react';
-
-import { MainUnauthorized } from './main-unauthorized';
+import { Communities } from './communities';
 import { MemoryRouter } from 'react-router';
 
-describe(MainUnauthorized, () => {
+describe(Communities, () => {
   it('should parse component correctly', () => {
     const wrapper = mount(
       <MemoryRouter>
-        <MainUnauthorized />
+        <Communities />
       </MemoryRouter>,
     );
-    expect(wrapper.html()).toContain('c-main-unauthorized');
+    expect(wrapper.html()).toContain('c-communities');
   });
 });

--- a/src/components/communities/communities.tsx
+++ b/src/components/communities/communities.tsx
@@ -1,0 +1,14 @@
+import React, { ReactElement } from 'react';
+
+import './communities.scss';
+import { CustomLink } from '../../utils/helpers';
+
+export function Communities(): ReactElement {
+  return (
+    <ul className="c-communities">
+      <li>
+        <CustomLink href="/group/1">Group 1</CustomLink>
+      </li>
+    </ul>
+  );
+}

--- a/src/components/communities/index.tsx
+++ b/src/components/communities/index.tsx
@@ -1,0 +1,1 @@
+export * from './communities';

--- a/src/components/main-unauthorized/main-unauthorized.tsx
+++ b/src/components/main-unauthorized/main-unauthorized.tsx
@@ -1,10 +1,11 @@
 import React, { ReactElement } from 'react';
 import './main-unauthorized.scss';
+import { Communities } from '../communities';
 
 export function MainUnauthorized(): ReactElement {
   return (
     <div className="c-main-unauthorized">
-      <div>left</div>
+      <Communities />
       <div>middle</div>
       <div>right</div>
     </div>


### PR DESCRIPTION
What
----

Added "Communities" component with single group for easier navigation. This PR closes #24 .

How to review
-------------

- Sanity check
- Run project
- You should see "Group 1" link on the left side
- Click on group link
- You should be redirected to group page